### PR TITLE
Update deploy options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ Simple Salesforce
 
 Simple Salesforce is a basic Salesforce.com REST API client built for Python 3.5, 3.6, 3.7 and 3.8. The goal is to provide a very low-level interface to the REST Resource and APEX API, returning a dictionary of the API JSON response.
 
+
 You can find out more regarding the format of the results in the `Official Salesforce.com REST API Documentation`_
 
 .. _Official Salesforce.com REST API Documentation: http://www.salesforce.com/us/developer/docs/api_rest/index.htm

--- a/simple_salesforce/metadata.py
+++ b/simple_salesforce/metadata.py
@@ -35,7 +35,7 @@ class SfdcMetadataApi:
             rollback_on_error = "<met:rollbackOnError>%s</met:rollbackOnError>" % options['rollbackOnError']
 
         single_package = ""
-        if 'singlepackage' in options:
+        if 'singlePackage' in options:
             single_package = "<met:singlePackage>%s</met:singlePackage>" % options['singlePackage']
 
         auto_update_package = ""

--- a/simple_salesforce/metadata.py
+++ b/simple_salesforce/metadata.py
@@ -27,11 +27,27 @@ class SfdcMetadataApi:
     def deploy(self, zipfile, options):
         """ Kicks off async deployment, returns deployment id """
         check_only = ""
-        if 'checkonly' in options:
+        if 'checkOnly' in options:
             check_only = "<met:checkOnly>%s</met:checkOnly>" % options['checkonly']
 
+        rollback_on_error = ""
+        if 'rollbackOnError' in options:
+            rollback_on_error = "<met:rollbackOnError>%s</met:rollbackOnError>" % options['rollbackOnError']
+
+        single_package = ""
+        if 'singlePackage' in options:
+            single_package = "<met:singlePackage>%s</met:singlePackage>" % options['singlePackage']
+
+        auto_update_package = ""
+        if 'autoUpdatePackage' in options:
+            auto_update_package = "<met:autoUpdatePackage>%s</met:autoUpdatePackage>" % options['autoUpdatePackage']
+
+        ignore_warnings = ""
+        if 'ignoreWarnings' in options:
+            ignore_warnings = "<met:ignoreWarnings>%s</met:ignoreWarnings>" % options['ignoreWarnings']
+
         test_level = ""
-        if 'testlevel' in options:
+        if 'testLevel' in options:
             test_level = "<met:testLevel>%s</met:testLevel>" % options['testlevel']
 
         tests_tag = ""
@@ -42,6 +58,10 @@ class SfdcMetadataApi:
         attributes = {
             'client': 'Metahelper',
             'checkOnly': check_only,
+            'rollbackOnError': rollback_on_error,
+            'singlePackage': single_package,
+            'autoUpdatePackage': auto_update_package,
+            'ignoreWarnings': ignore_warnings,
             'sessionId': self._session.get_session_id(),
             'ZipFile': self._read_deploy_zip(zipfile),
             'testLevel': test_level,

--- a/simple_salesforce/metadata.py
+++ b/simple_salesforce/metadata.py
@@ -35,7 +35,7 @@ class SfdcMetadataApi:
             rollback_on_error = "<met:rollbackOnError>%s</met:rollbackOnError>" % options['rollbackOnError']
 
         single_package = ""
-        if 'singlePackage' in options:
+        if 'singlepackage' in options:
             single_package = "<met:singlePackage>%s</met:singlePackage>" % options['singlePackage']
 
         auto_update_package = ""


### PR DESCRIPTION
## Summary

- adding deployOptions (see here https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy.htm) to set that are not present
- This allows these options to be used https://github.com/ncino/python-lib-salesforce/blob/master/lib_salesforce/deploy_api.py#L17-L23
- A new PR will be required in lib-salesforce to update this casing. 
- A new lambda layer can be built to use this change in any existing aws apps (Pogtopush)