### PR TITLE
DO-846 added rollBackonError field for mdapi

### DIFF
--- a/simple_salesforce/metadata.py
+++ b/simple_salesforce/metadata.py
@@ -144,6 +144,7 @@ class SfdcMetadataApi:
             'total_count': result.find('mt:numberComponentsTotal', self._XML_NAMESPACES).text,
             'failed_count': result.find('mt:numberComponentErrors', self._XML_NAMESPACES).text,
             'deployed_count': result.find('mt:numberComponentsDeployed', self._XML_NAMESPACES).text,
+            'rollbackOnError': result.find('mt:rollbackOnError', self._XML_NAMESPACES).text,
             'errors': deployment_errors
         }
         unit_test_detail = {


### PR DESCRIPTION
Adding `rollbackOnError` field to deployment detail so we can validate it in the PogtoPush integration tests.