### PR TITLE
fix: update api version for AdminsOnly field in installedPackage deploys

### DIFF
--- a/simple_salesforce/sfdc_session.py
+++ b/simple_salesforce/sfdc_session.py
@@ -5,7 +5,7 @@ from xml.etree import ElementTree as ET
 
 
 class SfdcSession(Session):
-    _DEFAULT_API_VERSION = "43.0"
+    _DEFAULT_API_VERSION = "57.0"
     _LOGIN_URL = "https://{instance}.salesforce.com"
     _SOAP_API_BASE_URI = "/services/Soap/c/{version}"
     _XML_NAMESPACES = {


### PR DESCRIPTION
Security Type field for AdminsOnly or AllUsers is only available in API Version 57.0 or later. 
https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_installedpackage.htm